### PR TITLE
#158787482 Use gradle build cache to improve gradle build speeds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+org.gradle.caching=true
 
 


### PR DESCRIPTION
#### What does this PR do?
Enables the gradle build cache in order to improve gradle build speeds.

#### What are the relevant pivotal tracker stories?
[#158787482](https://www.pivotaltracker.com/story/show/158787482)

#### Screenshots
(Note: These are the profiling reports obtained by running `./gradlew --profile --recompile-scripts --offline --rerun-tasks assembleDebug`)
Before enabling gradle build cache:
![screen shot 2018-11-27 at 12 34 32](https://user-images.githubusercontent.com/26762336/49073700-15aa9980-f244-11e8-98ab-4ba903722b6f.png)

After enabling gradle build cache:
![screen shot 2018-11-27 at 12 53 54](https://user-images.githubusercontent.com/26762336/49073728-23601f00-f244-11e8-90da-0e9dc651a579.png)
